### PR TITLE
Error in function ComposeURLParams

### DIFF
--- a/class/paycomet_bankstore.php
+++ b/class/paycomet_bankstore.php
@@ -1757,7 +1757,7 @@ class Paycomet_Bankstore
 			if ($content != "") {
 				$content .= "&";
 			}
-
+			$value = strval($value);
 			$content .= urlencode($key) . "=" . urlencode($value);
 		}
 
@@ -1768,7 +1768,7 @@ class Paycomet_Bankstore
 			if ($secureurlhash != "") {
 				$secureurlhash .= "&";
 			}
-
+			$value = strval($value);
 			$secureurlhash .= urlencode($key) . "=" . urlencode($value);
 		}
 


### PR DESCRIPTION
Without converting the $value into a string before doing the urlencode, I get a 500 error as soon as an integer gets encoded. I am using PHP in strict mode and urlencode only accepts strings as values.