### PR TITLE
Fix and clean url query generator

### DIFF
--- a/class/paycomet_bankstore.php
+++ b/class/paycomet_bankstore.php
@@ -1752,27 +1752,10 @@ class Paycomet_Bankstore
 			}
 		}
 
-		$content = "";
-		foreach ($data as $key => $value) {
-			if ($content != "") {
-				$content .= "&";
-			}
+		$content = http_build_query($data);
+		$VHASH = hash('sha512', md5($content.md5($this->password)));
 
-			$content .= urlencode($key) . "=" . urlencode($value);
-		}
-
-		$data["VHASH"] = hash('sha512', md5($content.md5($this->password)));
-
-		$secureurlhash = "";
-		foreach ($data as $key => $value) {
-			if ($secureurlhash != "") {
-				$secureurlhash .= "&";
-			}
-
-			$secureurlhash .= urlencode($key) . "=" . urlencode($value);
-		}
-
-		return $secureurlhash;
+		return $content."&VHASH=$VHASH";
 	}
 
 	/**

--- a/class/paycomet_bankstore.php
+++ b/class/paycomet_bankstore.php
@@ -1591,7 +1591,6 @@ class Paycomet_Bankstore
 	*/
 	private function ComposeURLParams($operationdata, $operationtype)
 	{
-		$secureurlhash = false;
 		$data = array();
 
 		$data["MERCHANT_MERCHANTCODE"] = $this->merchantCode;


### PR DESCRIPTION
Fix #1

- Usando `http_build_query()` que es mucho más rápido que hacerlo manualmente.
- Sólo se genera 1 vez.
- El `$VHASH` no necesita `urlencode()`. Todos los hash SHA1 y MD5 son alfanuméricos 0-9a-z.

Hemos sustituido 20 líneas por 3 líneas y es 20 veces más rápido.

Tengo muchos más cambios en esta clase y la nueva de composer sin romper compatibilidad, pero no se si estan abiertos a PRs.